### PR TITLE
修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@
 7、[各nas dpanel 部署教程及食用方法](https://github.com/FrozenGEE/compose/blob/main/dpanel.md)
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=FrozenGEE/compose&type=Date)](https://star-history.com/#FrozenGEE/compose&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=FrozenGEE/compose&type=Date)](https://star-history.dera.page/#FrozenGEE/compose&Date)


### PR DESCRIPTION
README 中的 Star History 图表因为 GitHub 星标数据接口的限制已经无法正常显示，导致项目主页介绍处一直展示着损坏的图表，影响观感。

本次修改将其切换为可正常工作的数据源，图片与跳转链接均已同步更新，图表可以恢复正常更新显示。请合并此修复，避免项目主页一直出现损坏的图表。